### PR TITLE
🗺️ Zoomify Generator: Extend Vips processor

### DIFF
--- a/extend/README.md
+++ b/extend/README.md
@@ -1,0 +1,30 @@
+### Config object
+| Property           | Default Value | Value Type | Description | Accepted Values |
+|--------------------|---------------|------------|---|-------------------|
+| processor          | 'GD'          | string     | The image processing library to use | 'GD', 'Imagick', 'ImageMagick', 'Vips'  |
+| filepath           | None          | string     | The path to the input image   | Any valid file path to an image file (e.g., 'input/image-path') |
+| destinationDir     | None          | string     | The path to the destination directory where the tiles will be saved | Any valid directory path (e.g., 'output-path')  |
+| destinationRemove  | false         | boolean    | Whether to remove existing content in the destination directory before processing  | true, false |
+| dirMode            | 0755          | int        | The file system mode (permissions) for created directories  | Any valid Unix file system mode (e.g., 0755, 0775, 0777)  |
+| tileSize           | 256           | int        | The size of the tiles in pixels  | Any positive integer value (e.g., 256, 512, 1024)  |
+| tileOverlap        | 0             | int        | The overlap of tiles in pixels   | Any non-negative integer value (e.g., 0, 1, 2)     |
+| tileFormat         | 'jpg'         | string     | The format of the output tiles   | 'jpg', 'png', 'gif', or any other supported image format by the selected processor           |
+| tileQuality        | 85            | int        | The quality of the output tiles (only applicable for lossy formats like JPEG)                         | Any integer value between 1 and 100 (inclusive), where 1 is the lowest quality (highest compression) and 100 is the highest quality (lowest compression) |
+| * tileLayout        | 'zoomiy'            | string        | Supported output layout for libvips  | allowed: dz, zoomify, google, iiif, iiif3 |  
+
+#### Note for dz layout
+- In this layout, to make sure the files are generated into the correct folder, we should add the output name like: {out_folder}/output, this will create a output.dzi and output_files folder to the directory
+
+#### Example
+```
+// Set your configuration options
+$config = [
+    'tileLayout' => 'deepzoom'
+    'tileSize' => 512,
+    'tileOverlap' => 0,
+    'tileQuality' => 100,
+    'destinationRemove' => true,
+    'processor' => 'Vips'
+];
+```
+

--- a/extend/extendZoomify.php
+++ b/extend/extendZoomify.php
@@ -2,32 +2,72 @@
 
 namespace ZoomImage;
 
-require 'vendor/autoload.php';
-
 // use Imagick;
 use DanielKm\Zoomify\Zoomify;
+use ZoomImage\ExtendZoomify;
 
 class ExtendZoomify extends Zoomify
 {
     // Add a new property to the config
-    protected $tileFormat = 'zoomify';
+    protected $tileLayout = 'zoomify';
 
     public function __construct(array $config = null)
     {
-        // Assign the new property from the config array
-        if (isset($config['tileFormat'])) {
-            $this->tileFormat = $config['tileFormat'];
+        if (is_null($config)) {
+            $config = [];
         }
 
-        parent::__construct($config);
+        $this->config = $config;
+        if (isset($config['processor'])) {
+            $this->processor = $config['processor'];
+        }
 
-        // Add support for the new processor
-        if ($this->processor == 'ExtendedVips') {
-            require_once __DIR__ . DIRECTORY_SEPARATOR . '/src/ZoomifyVips.php';
-            $processor = new ZoomifyVips();
+        // Assign the new property from the config array
+        if (isset($config['tileLayout'])) {
+            $this->tileLayout = $config['tileLayout'];
+        }
+        
+        // Handle the new processor case first
+        if (isset($config['processor']) && $config['processor'] == 'ExtendVips') {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . '/ExtendZoomifyVips.php';
+            $processor = new ExtendZoomifyVips();
             if (!$processor->getVipsPath()) {
                 throw new \Exception('Vips path is not available.');
             }
+        } else {
+            // Call the parent constructor for other processors
+            parent::__construct($config);
         }
     }
+
+    /**
+     * Zoomify the specified image and store it in the destination dir.
+     *
+     * Check to be sure the file hasn't been converted already.
+     *
+     * @param string $filepath The path to the image.
+     * @param string $destinationDir The directory where to store the tiles.
+     * @return bool
+     */
+    public function process($filepath, $destinationDir = '')
+    {
+        // If the processor is not 'ExtendVips', call the parent process method
+        if ($this->processor != 'ExtendVips') {
+            try {
+                $result = parent::process($filepath, $destinationDir);
+            } catch (\Exception $e) {
+                // Handle the exception as needed
+                // For example, you can throw a custom exception or log the error message
+                throw new \Exception('Error during processing: ' . $e->getMessage());
+            }
+            return $result;
+        } else {
+            // If the processor is 'ExtendVips', use the custom processor
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'ExtendZoomifyVips.php';
+            $processor = new ExtendZoomifyVips($this->config);
+            $result = $processor->process($filepath, $destinationDir);
+            return $result;
+        }
+    }
+
 }

--- a/extend/extendZoomify.php
+++ b/extend/extendZoomify.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ZoomImage;
+
+require 'vendor/autoload.php';
+
+// use Imagick;
+use DanielKm\Zoomify\Zoomify;
+
+class ExtendZoomify extends Zoomify
+{
+    // Add a new property to the config
+    protected $tileFormat = 'zoomify';
+
+    public function __construct(array $config = null)
+    {
+        // Assign the new property from the config array
+        if (isset($config['tileFormat'])) {
+            $this->tileFormat = $config['tileFormat'];
+        }
+
+        parent::__construct($config);
+
+        // Add support for the new processor
+        if ($this->processor == 'ExtendedVips') {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . '/src/ZoomifyVips.php';
+            $processor = new ZoomifyVips();
+            if (!$processor->getVipsPath()) {
+                throw new \Exception('Vips path is not available.');
+            }
+        }
+    }
+}

--- a/extend/extendZoomifyVips.php
+++ b/extend/extendZoomifyVips.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace ZoomImage;
+
+use DanielKm\Zoomify\ZoomifyVips;
+
+class ExtendZoomifyVips extends ZoomifyVips
+{
+    /**
+     * Zoomify the specified image and store it in the destination dir.
+     *
+     * Check to be sure the file hasn't been converted already.
+     *
+     * @param string $filepath The path to the image.
+     * @param string $destinationDir The directory where to store the tiles.
+     * @return bool
+     */
+    public function process($filepath, $destinationDir = '')
+    {
+        $this->_imageFilename = realpath($filepath);
+        $this->filepath = realpath($filepath);
+        $this->destinationDir = $destinationDir;
+        $result = $this->createDataContainer();
+        if (!$result) {
+            trigger_error('Output directory already exists.', E_USER_WARNING);
+            return false;
+        }
+
+        $vipsTileLayout;
+        $vipsTileOutput;
+
+        switch($this->config['tileLayout']) {
+            case 'zoomify':
+            default: 
+                $vipsTileLayout = 'zoomify';
+                $vipsTileOutput = escapeshellarg($this->_saveToLocation);
+                break;
+            case 'deepzoom':
+                $vipsTileLayout = 'dz';
+                $vipsTileOutput = escapeshellarg($this->_saveToLocation).'/output';
+                break;
+        }
+
+        $command = sprintf(
+            '%s dzsave %s %s --layout %s --suffix %s --overlap %s --tile-size %s --background "0 0 0" --properties',
+            'vips',
+            escapeshellarg($this->filepath),
+            $vipsTileOutput,
+            $vipsTileLayout,
+            escapeshellarg('.' . $this->tileFormat . '[Q=' . (int) $this->tileQuality . ']'),
+            (int) $this->tileOverlap,
+            (int) $this->tileSize
+        );
+        $result = $this->execute($command);
+        if ($result === false) {
+            return false;
+        }
+
+        // For an undetermined reason, the vips xml may be saved in a sub-folder
+        // on some servers.
+        $filevips = $this->_saveToLocation . '/' . basename($this->_saveToLocation) . '/vips-properties.xml';
+        if (file_exists($filevips)) {
+            rename($filevips, $this->_saveToLocation . '/vips-properties.xml');
+            rmdir($this->_saveToLocation . '/' . basename($this->_saveToLocation));
+        }
+        return true;
+    }
+
+    /**
+     * Helper to get the command line tool vips.
+     *
+     * @return string
+     */
+    public function getVipsPath()
+    {
+        return 'vips';
+    }
+}

--- a/run.php
+++ b/run.php
@@ -1,9 +1,8 @@
 <?php
 require 'vendor/autoload.php';
+require './extend/extendZoomify.php';
 
-// use Imagick;
-use DanielKm\Zoomify\Zoomify;
-use DanielKm\Zoomify\ZoomifyFactory;
+use ZoomImage\ExtendZoomify;
 
 // Set your configuration options
 $globalConfig = [
@@ -101,9 +100,6 @@ $config = [
     "destinationRemove" => true,
 ];
 
-// Setup the Zoomify library
-$factory = new ZoomifyFactory();
-
 // Loop through the $images array and process each image
 foreach ($images as $image) {
     if ($image['enable']) {
@@ -113,8 +109,8 @@ foreach ($images as $image) {
         $source = $image['source'];
         $destination = $image['destination'].'--'.$config['tileFormat'];
 
-        // Setup the Zoomify library with the merged config
-        $zoomify = $factory($config);
+        // Setup the Zoomify library.
+        $zoomify = new ExtendZoomify($config);
 
         // Process the source file and save tiles in the destination folder
         $result = $zoomify->process($source, $destination);

--- a/run.php
+++ b/run.php
@@ -7,12 +7,12 @@ use ZoomImage\ExtendZoomify;
 // Set your configuration options
 $globalConfig = [
     // Add your config options here
-    'tileFormat' => 'zoomify',
-    'tileSize' => 256,
+    'tileLayout' => 'deepzoom',
+    'tileSize' => 512,
     'tileOverlap' => 0,
     'tileQuality' => 100,
     'destinationRemove' => true,
-    'processor' => 'GD'
+    'processor' => 'ExtendVips'
 ];
 
 function getFolderSizeAndFileCount($dir) {
@@ -84,7 +84,6 @@ $images = [
         'source' => 'input/pexels-max-rahubovskiy-5997992.jpg',
         'destination' => 'output/'.'pexels-max-rahubovskiy-5997992',
         'config' => [ /* image specific configs */
-            'tileSize' => 256
         ],
         'enable' => true,
     ]
@@ -107,7 +106,7 @@ foreach ($images as $image) {
         $config = array_merge($globalConfig, $image['config']);
 
         $source = $image['source'];
-        $destination = $image['destination'].'--'.$config['tileFormat'];
+        $destination = $image['destination'].'--'.$config['tileLayout'];
 
         // Setup the Zoomify library.
         $zoomify = new ExtendZoomify($config);
@@ -122,13 +121,13 @@ foreach ($images as $image) {
 
         // Grab the result of all images into JSON file
         $fileOutput = array(
-            "image" => $image["name"].'--'.$config['tileFormat'],
+            "image" => $image["name"].'--'.$config['tileLayout'],
             "status" => $result,
             "fileCount" => $fileCount - 1,
             "folderSize" => $folderSize,
             "tileSize" => $config['tileSize'],
             "tileOverlap" => $config['tileOverlap'],
-            "format" => $config['tileFormat']
+            "format" => $config['tileLayout']
         );
 
         // Create a resized version of the image

--- a/run.php
+++ b/run.php
@@ -7,7 +7,7 @@ use ZoomImage\ExtendZoomify;
 // Set your configuration options
 $globalConfig = [
     // Add your config options here
-    'tileLayout' => 'deepzoom',
+    'tileLayout' => 'zoomify',
     'tileSize' => 512,
     'tileOverlap' => 0,
     'tileQuality' => 100,
@@ -84,6 +84,16 @@ $images = [
         'source' => 'input/pexels-max-rahubovskiy-5997992.jpg',
         'destination' => 'output/'.'pexels-max-rahubovskiy-5997992',
         'config' => [ /* image specific configs */
+            "tileSize" => 512,
+        ],
+        'enable' => true,
+    ],
+    [
+        'name' => 'pexels-max-rahubovskiy-5997992',
+        'source' => 'input/pexels-max-rahubovskiy-5997992.jpg',
+        'destination' => 'output/'.'pexels-max-rahubovskiy-5997992',
+        'config' => [ /* image specific configs */
+            'tileLayout' => 'deepzoom',
         ],
         'enable' => true,
     ]


### PR DESCRIPTION
## Summary
- To fix the Vips PATH issue, extend the default classed to hard code the path value
- Also extend class will accept new config `tileFormat` to extend the Vips library generation: so far tested with dz and zoomify

## Testing
- Update image configs and re run `run.php` and test against localhost:8000
- Confirm the output for dzi is: output.dzi and output_files in the designated folder

## Reference
#13 